### PR TITLE
Use ENABLE_PARTIAL_WRITE and ACCEPT_MOVING_WRITE_BUFFER flags to fix large write calls through ssl

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -472,6 +472,7 @@ mod openssl {
     impl Default for OpensslClient {
         fn default() -> OpensslClient {
             let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
+            println!("Openssl client??");
             ctx.set_default_verify_paths().unwrap();
             ctx.set_options(
                 SslOptions::NO_SSLV2 |
@@ -524,12 +525,14 @@ mod openssl {
 
     impl Default for Openssl {
         fn default() -> Openssl {
+            let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
+            ctx.set_mode(
+                SslMode::ENABLE_PARTIAL_WRITE |
+                SslMode::ACCEPT_MOVING_WRITE_BUFFER
+            );
+            println!("Openssl??");
             Openssl {
-                context: SslContext::builder(SslMethod::tls()).unwrap_or_else(|e| {
-                    // if we cannot create a SslContext, that's because of a
-                    // serious problem. just crash.
-                    panic!("{}", e)
-                }).build()
+                context: ctx.build()
             }
         }
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -441,7 +441,7 @@ mod openssl {
     use error::Error;
     use openssl::error::ErrorStack;
     use openssl::ssl::{ErrorCode, SslVerifyMode, Ssl, SslFiletype,
-        SslContext, SslMethod, SslStream, SslOptions, HandshakeError};
+        SslContext, SslMethod, SslStream, SslMode, SslOptions, HandshakeError};
 
     use super::{HttpStream, Blocked};
 
@@ -473,7 +473,13 @@ mod openssl {
         fn default() -> OpensslClient {
             let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
             ctx.set_default_verify_paths().unwrap();
-            ctx.set_options(SslOptions::NO_SSLV2 | SslOptions::NO_SSLV3 | SslOptions::NO_COMPRESSION);
+            ctx.set_options(
+                SslOptions::NO_SSLV2 |
+                SslOptions::NO_SSLV3 |
+                SslOptions::NO_COMPRESSION
+            );
+            ctx.set_mode(SslMode::ENABLE_PARTIAL_WRITE);
+
             // cipher list taken from curl:
             // https://github.com/curl/curl/blob/5bf5f6ebfcede78ef7c2b16daa41c4b7ba266087/lib/vtls/openssl.h#L120
             ctx.set_cipher_list("ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH").unwrap();

--- a/src/net.rs
+++ b/src/net.rs
@@ -472,7 +472,6 @@ mod openssl {
     impl Default for OpensslClient {
         fn default() -> OpensslClient {
             let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
-            println!("Openssl client??");
             ctx.set_default_verify_paths().unwrap();
             ctx.set_options(
                 SslOptions::NO_SSLV2 |
@@ -530,7 +529,6 @@ mod openssl {
                 SslMode::ENABLE_PARTIAL_WRITE |
                 SslMode::ACCEPT_MOVING_WRITE_BUFFER
             );
-            println!("Openssl??");
             Openssl {
                 context: ctx.build()
             }

--- a/src/net.rs
+++ b/src/net.rs
@@ -478,7 +478,10 @@ mod openssl {
                 SslOptions::NO_SSLV3 |
                 SslOptions::NO_COMPRESSION
             );
-            ctx.set_mode(SslMode::ENABLE_PARTIAL_WRITE);
+            ctx.set_mode(
+                SslMode::ENABLE_PARTIAL_WRITE |
+                SslMode::ACCEPT_MOVING_WRITE_BUFFER
+            );
 
             // cipher list taken from curl:
             // https://github.com/curl/curl/blob/5bf5f6ebfcede78ef7c2b16daa41c4b7ba266087/lib/vtls/openssl.h#L120


### PR DESCRIPTION
Problem: testing with schedule-all-the-things was getting an error when trying to send the GCM notification specifically. Looking up the error ("bad write"), other posts led me to believe that the problem is that the notification payload is too large to write in a single call (note that we duplicate a large string 999 times when creating a gcm notification for schedule-all-the-things). 

Looking at a php patch referenced by a github issue with this error, they add the flags ENABLE_PARTIAL_WRITE and ACCEPT_MOVING_WRITE_BUFFER (https://github.com/php/php-src/commit/17e9fc9bfeaf575b25782a42937a56e809155858).

Therefore I added ENABLE_PARTIAL_WRITE and ACCEPT_MOVING_WRITE_BUFFER flags to both OpensslClient and Openssl through the openssl context. 

Note that .set_mode() corresponds to SSL_CTX_set_mode (https://docs.rs/openssl/0.10.2/openssl/ssl/struct.SslContextBuilder.html#method.set_mode), and SSL_CTX_set_mode does not clear options that were already set (https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_mode.html).